### PR TITLE
LoadBatchCellsThreaded -> LoadBatchCellsThreadedAsync

### DIFF
--- a/MapRoomScanningImprovements/Extensions/MapRoomFunctionalityExtensions.cs
+++ b/MapRoomScanningImprovements/Extensions/MapRoomFunctionalityExtensions.cs
@@ -45,9 +45,7 @@ namespace MapRoomScanningImprovements.Extensions
 
                         batchCells = BatchCells.GetFromPool(cellManager, largeWorldStreamer, batch);
 
-                        var loadBatchCellsTask = new LoadBatchCellsTask(cellManager, batchCells);
-                        UWE.Utils.EnqueueWrap(workerThread, loadBatchCellsTask);
-                        yield return new AsyncAwaiter(loadBatchCellsTask);
+                        yield return cellManager.LoadBatchCellsThreadedAsync(batchCells, false);
 
                         batchVisible = false;
                     }

--- a/MapRoomScanningImprovements/Extensions/MapRoomFunctionalityExtensions.cs
+++ b/MapRoomScanningImprovements/Extensions/MapRoomFunctionalityExtensions.cs
@@ -238,7 +238,7 @@ namespace MapRoomScanningImprovements.Extensions
             {
                 try
                 {
-                    cellManager.LoadBatchCellsThreaded(batchCells);
+                    cellManager.LoadBatchCellsThreadedAsync(batchCells, false);
                 }
                 catch (Exception exception)
                 {

--- a/MapRoomScanningImprovements/Extensions/MapRoomFunctionalityExtensions.cs
+++ b/MapRoomScanningImprovements/Extensions/MapRoomFunctionalityExtensions.cs
@@ -12,8 +12,6 @@ namespace MapRoomScanningImprovements.Extensions
 {
     static class MapRoomFunctionalityExtensions
     {
-        private static WorkerThread workerThread = ThreadUtils.StartWorkerThread("I/O", "ScannerThread", System.Threading.ThreadPriority.BelowNormal, -2, 32);
-
         public static IEnumerator ScanInSleepingBatchCellsNotQueuesCoroutine(this MapRoomFunctionality mapRoom, int numOfBatchRings)
         {
             var watch = new Stopwatch();
@@ -70,7 +68,7 @@ namespace MapRoomScanningImprovements.Extensions
                                 {
                                     serialData = new SerialData();
                                     serialData.CopyFrom(entityCell.GetSerialData());
-                                } 
+                                }
                                 else
                                 {
                                     serialData = entityCell.GetSerialData();
@@ -222,42 +220,6 @@ namespace MapRoomScanningImprovements.Extensions
             Logger.Info(string.Format("Finishing scan in sleeping/unloaded BatchCells in {0} ms", watch.ElapsedMilliseconds));
 
             yield break;
-        }
-    
-        private sealed class LoadBatchCellsTask : IWorkerTask, IAsyncOperation
-        {
-            public LoadBatchCellsTask(CellManager cellManager, BatchCells batchCells)
-            {
-                this.cellManager = cellManager;
-                this.batchCells = batchCells;
-            }
-
-            public void Execute()
-            {
-                try
-                {
-                    cellManager.LoadBatchCellsThreadedAsync(batchCells, false);
-                }
-                catch (Exception exception)
-                {
-                    UnityEngine.Debug.LogException(exception);
-                }
-                finally
-                {
-                    isDone = true;
-                }
-            }
-
-            public bool isDone { get; private set; }
-
-            public override string ToString()
-            {
-                return string.Format("LoadBatchCellsTask {0}", batchCells.batch);
-            }
-
-            private readonly CellManager cellManager;
-
-            private readonly BatchCells batchCells;
         }
     }
 }


### PR DESCRIPTION
Related: [Only loads some resources, not ones at the edge of max range (250-500m)](https://www.nexusmods.com/subnautica/mods/406?tab=bugs)

This fixes the issue with the mod not finishing scanning (i.e. no `Finishing scan in sleeping/unloaded BatchCells...` message).  I assume the game was updated and this method renamed, maybe?  I am not sure why there's not error in the logs if this is indeed the case.  We can do a dynamic solution that tries both method names if you wish.

In the save game scenario I uploaded, it will now find magnetite and a few other things it didn't originally find.  Note that it did originally find some things, but didn't finish the scan.

However, it will still not find blood oil, and the scanner will not find the magnetite over where the camera drone is (even though the above lists it).  I tried increasing the `numOfBatchRings` value, but this didn't seem to make a difference.